### PR TITLE
Correct random to pseudo-random. Add information.

### DIFF
--- a/go/not-so-random.md
+++ b/go/not-so-random.md
@@ -1,8 +1,8 @@
 # Not So Random
 
-Go's `rand` package makes it easy to generate all sorts of random numbers.
-What they don't tell you though is that the default seed is `1`. So if you
-write a program like so:
+Go's `rand` package makes it easy to generate all sorts of pseudo-random numbers.
+
+What they don't tell you though is that the default seed is `1`. They [do tell you that the numbers are pseud-random and that you need to use the Seed function to initialize the default source if different behavior is required for each run](https://golang.org/pkg/math/rand/), though. So if you write a program like so:
 
 ```go
 package main
@@ -35,7 +35,7 @@ seed it yourself, perhaps with the current time, instead of `1`. Try adding
 the following to the beginning of the `main` function:
 
 ```go
-rand.Seed( time.Now().UTC().UnixNano())
+rand.Seed(time.Now().UTC().UnixNano())
 ```
 
 You'll also want to import the `time` package.
@@ -43,4 +43,4 @@ You'll also want to import the `time` package.
 Things should *appear* to be a bit more random now.
 
 source: [Jake Worth](https://twitter.com/jwworth) and
-[Stackoverflow](http://stackoverflow.com/questions/12321133/golang-random-number-generator-how-to-seed-properly) 
+[Stackoverflow](http://stackoverflow.com/questions/12321133/golang-random-number-generator-how-to-seed-properly)


### PR DESCRIPTION
* Correcting "random" to "pseudo-random".
* Adding link to the documentation page for `math/rand`, where the first five sentences are pretty informative.