### PR TITLE
Fix the expected result of immutable remove operation

### DIFF
--- a/javascript/immutable-remove-with-the-spread-operator.md
+++ b/javascript/immutable-remove-with-the-spread-operator.md
@@ -15,10 +15,8 @@ const remove = (items,index) => {
 };
 
 const list = [1,2,3,4,5];
-remove(list, 2);
-// [1,2,3,4]
-list
-// [1,2,3,4,5]
+remove(list, 2); // [1,2,4,5]
+// list still [1,2,3,4,5]
 ```
 
 It only took a couple lines of code and immutability is baked in.


### PR DESCRIPTION
This PR aims to fix the expected result of Javascript immutable remove operation from `[1,2,3,4]` to `[1,2,4,5]` since it removes the third array element (index 2).