### PR TITLE
Update brew cask command

### DIFF
--- a/workflow/convert-an-epub-document-to-pdf-on-mac.md
+++ b/workflow/convert-an-epub-document-to-pdf-on-mac.md
@@ -6,7 +6,7 @@ convert it using the `ebook-convert` binary from `Calibre`.
 First, install `Calibre`:
 
 ```bash
-$ brew cask install calibre
+$ brew install --cask calibre
 ```
 
 Then convert your ePub using `ebook-convert`:


### PR DESCRIPTION
[`brew cask` is no longer a `brew` command](https://github.com/Homebrew/brew/pull/8899). Now, users need to use `brew install --cask` instead.