### PR TITLE
Add missing parens to jq inside call

### DIFF
--- a/jq/filter-out-results-based-on-list-of-values.md
+++ b/jq/filter-out-results-based-on-list-of-values.md
@@ -23,7 +23,7 @@ can filter the array down to those objects whose IDs are
 exclude.
 
 ```
-jq '.[] | select([.id] | inside["456", "963"] | not)' data.json
+jq '.[] | select([.id] | inside(["456", "963"]) | not)' data.json
 ```
 
 Inside that `select`, we grab the `id` as a single value array, check if that


### PR DESCRIPTION
This example was helpful, but it's missing the parentheses. Also jq's error messages are really not great: `jq: error: inside/0 is not defined at <top-level>, line 1`