### PR TITLE
Fix Calibre installation command in documentation

### DIFF
--- a/workflow/convert-an-epub-document-to-pdf-on-mac.md
+++ b/workflow/convert-an-epub-document-to-pdf-on-mac.md
@@ -6,7 +6,7 @@ convert it using the `ebook-convert` binary from `Calibre`.
 First, install `Calibre`:
 
 ```bash
-$ brew cask install calibre
+$ brew install --cask calibre
 ```
 
 Then convert your ePub using `ebook-convert`:


### PR DESCRIPTION
Updated installation command for Calibre to use the latest Homebrew syntax. 

(This is what brew suggested to me, it seemed to work)